### PR TITLE
Remove maps on infrastructure change

### DIFF
--- a/web/client/src/components/infrastructure/infrastructure-map.vue
+++ b/web/client/src/components/infrastructure/infrastructure-map.vue
@@ -105,6 +105,7 @@ export default defineComponent({
 
     watch: {
         currentInfrastructure(newInfrastructure: string | null) {
+            this.libreGLMap?.remove();
             // Re-instantiating the map on infrastructure change currently leads to duplicated icon fetching on change.
             // @ts-ignore type instantiation for some reason is too deep
             this.libreGLMap = newInfrastructure ? this.createMap(newInfrastructure) : null;


### PR DESCRIPTION
Removes maps upon changing the infrastructure, which makes changing the infrastructure mid-runtime possible again.

* Closes #33 