### PR TITLE
Rename soro client target

### DIFF
--- a/web/CMakeLists.txt
+++ b/web/CMakeLists.txt
@@ -3,4 +3,4 @@ add_subdirectory(client)
 
 add_custom_target(soro-server-client)
 add_dependencies(soro-server-client soro-server)
-add_dependencies(soro-server-client soro-client-production)
+add_dependencies(soro-server-client soro-client)

--- a/web/client/CMakeLists.txt
+++ b/web/client/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 project(soro)
 
-add_custom_target(soro-client-production COMMAND npm run build WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-add_custom_command(TARGET soro-client-production POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
+add_custom_target(soro-client COMMAND npm run build WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+add_custom_command(TARGET soro-client POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory
         ${CMAKE_CURRENT_SOURCE_DIR}/dist
         ${SORO_SERVER_DIR}/server_resources)

--- a/web/client/README.md
+++ b/web/client/README.md
@@ -27,6 +27,6 @@ ninja
 
 Then simply execute
 ```shell
-ninja soro-client-production
+ninja soro-client
 ```
 This target has also been added to the `soro-server-client` target for convenience.


### PR DESCRIPTION
The soro-client target for building the web client was named `soro-client-production` due to an earlier name conflict. As this name conflict was nullified with the removal of emplace.js, we can now rename this target.