### PR TITLE
Add dependent issues workflow

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -12,8 +12,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - name: Dependent issues
-        uses: z0al/dependent-issues@v1
+      - uses: z0al/dependent-issues@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,11 +2,7 @@ name: Dependent Issues
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - edited
-      - closed
-      - reopened
+    types: [ opened, edited, closed, reopened ]
 
 jobs:
   check:

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,7 +1,7 @@
 name: Dependent Issues
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,27 @@
+name: Dependent Issues
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - closed
+      - reopened
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dependent issues
+        uses: z0al/dependent-issues@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          label: dependent
+          keywords: depends on, blocked by
+          comment: >
+            This PR/issue depends on:
+
+            {{ dependencies }}
+
+            By **[Dependent Issues](https://github.com/z0al/dependent-issues)** (🤖). Happy coding!

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -2,7 +2,11 @@ name: Dependent Issues
 
 on:
   pull_request_target:
-    types: [ opened, edited, closed, reopened ]
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
 
 jobs:
   check:


### PR DESCRIPTION
Adds the dependent issues workflow from https://github.com/z0al/dependent-issues.

This way we can control the dependencies of pull requests using keywords and get a pending job for our pull request CI to make dependencies more obvious.

![image](https://user-images.githubusercontent.com/78490564/219410243-82811ced-e3e4-4e72-a9b5-2928501cd622.png)