### PR TITLE
Visualize bridges from OSM data

### DIFF
--- a/web/client/src/components/infrastructure/mapStyle.ts
+++ b/web/client/src/components/infrastructure/mapStyle.ts
@@ -48,6 +48,22 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                 }
             },
             {
+                'id': 'bridges',
+                'type': 'line',
+                'source': 'osm',
+                'source-layer': 'rail',
+                'filter': ['==', 'rail', 'bridges'],
+                'paint': {
+                    'line-color': [
+                        'case',
+                        ['has', 'color'], ['get', 'color'],
+                        '#444'
+                    ],
+                    'line-width': 6.0,
+                    'line-blur': 7
+                }
+            },
+            {
                 'id': 'rail',
                 'type': 'line',
                 'source': 'osm',

--- a/web/client/src/components/infrastructure/mapStyle.ts
+++ b/web/client/src/components/infrastructure/mapStyle.ts
@@ -75,7 +75,7 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                         '#444',
                     ],
                     'line-width': 3.0,
-                }
+                },
             },
             {
                 'id': 'station-route-layer',

--- a/web/client/src/components/infrastructure/mapStyle.ts
+++ b/web/client/src/components/infrastructure/mapStyle.ts
@@ -74,7 +74,7 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                         ['has', 'color'], ['get', 'color'],
                         '#444',
                     ],
-                    'line-width': 3.0,
+                    'line-width': 3.5,
                 },
             },
             {

--- a/web/client/src/components/infrastructure/mapStyle.ts
+++ b/web/client/src/components/infrastructure/mapStyle.ts
@@ -48,22 +48,6 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                 }
             },
             {
-                'id': 'bridges',
-                'type': 'line',
-                'source': 'osm',
-                'source-layer': 'rail',
-                'filter': ['==', 'rail', 'bridges'],
-                'paint': {
-                    'line-color': [
-                        'case',
-                        ['has', 'color'], ['get', 'color'],
-                        '#444'
-                    ],
-                    'line-width': 6.0,
-                    'line-blur': 7
-                }
-            },
-            {
                 'id': 'rail',
                 'type': 'line',
                 'source': 'osm',
@@ -76,6 +60,21 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                         '#444'
                     ],
                     'line-width': 2.0
+                }
+            },
+            {
+                'id': 'bridges',
+                'type': 'line',
+                'source': 'osm',
+                'source-layer': 'rail',
+                'filter': ['==', 'rail', 'bridges'],
+                'paint': {
+                    'line-color': [
+                        'case',
+                        ['has', 'color'], ['get', 'color'],
+                        '#444'
+                    ],
+                    'line-width': 3.0,
                 }
             },
             {

--- a/web/client/src/components/infrastructure/mapStyle.ts
+++ b/web/client/src/components/infrastructure/mapStyle.ts
@@ -57,7 +57,7 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                     'line-color': [
                         'case',
                         ['has', 'color'], ['get', 'color'],
-                        '#444'
+                        '#444',
                     ],
                     'line-width': 2.0
                 }
@@ -72,7 +72,7 @@ export const createInfrastructureMapStyle = ({ currentTheme, activatedElements }
                     'line-color': [
                         'case',
                         ['has', 'color'], ['get', 'color'],
-                        '#444'
+                        '#444',
                     ],
                     'line-width': 3.0,
                 }

--- a/web/server/profile/profile.lua
+++ b/web/server/profile/profile.lua
@@ -102,6 +102,7 @@ function process_way(way)
       way:set_target_layer("rail")
       way:set_approved_min(5)
       way:add_string("rail", "bridges")
+      way:add_tag_as_string("color")
     else
       way:set_target_layer("rail")
       way:set_approved_min(5)

--- a/web/server/profile/profile.lua
+++ b/web/server/profile/profile.lua
@@ -98,6 +98,10 @@ function process_way(way)
       way:set_approved_min(10)
       way:add_string("rail", "secondary")
 
+    elseif way:has_tag("bridge","yes") then
+      way:set_target_layer("rail")
+      way:set_approved_min(5)
+      way:add_string("rail", "bridges")
     else
       way:set_target_layer("rail")
       way:set_approved_min(5)


### PR DESCRIPTION
Tunnels available in the OSM data are now painted over other non-bridge ways. This clarifies wether two ways meet if one of them is a bridge

<img width="565" alt="image" src="https://user-images.githubusercontent.com/117826826/223390022-7bdce70e-ee39-4f87-9d3d-f5df188a59b8.png">

Bridges are also drawn a little bit wider to make it more clear that they are not connected to the crossed rail

