### PR TITLE
Ignore transform-osm executable on ubuntu

### DIFF
--- a/generate-osm/.gitignore
+++ b/generate-osm/.gitignore
@@ -3,4 +3,4 @@ temp/*
 output/*
 
 *.exe
-
+transform-osm


### PR DESCRIPTION
Corrects the go executable in gitignore to also be ignored on ubuntu. You may have to `git rm --cached transform-osm` for it to fully work (untrack the file from git itself).