### PR TITLE
Remove Wiesbaden Hauptbahnhof addition

### DIFF
--- a/generate-osm/osm-utils/generate-stations.go
+++ b/generate-osm/osm-utils/generate-stations.go
@@ -42,7 +42,6 @@ func generateSearchFile(osm Osm) (searchFile SearchFile, stationHaltOsm Osm) {
 	stations := make(map[string]Station)
 	halts := make(map[string]Halt)
 	stationHaltsNodes := make([]*Node, 0)
-	osm.Node = append(osm.Node, getWiesbadenHbfAsNode())
 
 	for _, node := range osm.Node {
 		var name string = ""
@@ -80,20 +79,4 @@ func generateSearchFile(osm Osm) (searchFile SearchFile, stationHaltOsm Osm) {
 		}, Osm{
 			Node: stationHaltsNodes,
 		}
-}
-
-func getWiesbadenHbfAsNode() *Node {
-	return &Node{
-		Id:        "420133769",
-		Version:   "1",
-		Timestamp: "2021-03-01T14:00:00Z",
-		Lat:       "50.06988",
-		Lon:       "8.24404",
-		Tag: []*Tag{
-			{K: "name", V: "Wiesbaden Hauptbahnhof"},
-			{K: "railway", V: "station"},
-			{K: "railway:ref", V: "FW"},
-			{K: "public_transport", V: "station"},
-		},
-	}
 }


### PR DESCRIPTION
Previously, Wiesbaden Hauptbahnhof was manually patched into OSM Data in the preprocessing script. As of https://www.openstreetmap.org/changeset/132926044, Wiesbaden Hauptbahnhof is marked and discovered correctly by OSM.

This means the manual patch can be removed.

* Related to #43 