### PR TITLE
Allow saving legend controls

### DIFF
--- a/web/client/src/components/golden-layout-components/InfrastructureComponent.vue
+++ b/web/client/src/components/golden-layout-components/InfrastructureComponent.vue
@@ -10,30 +10,20 @@ import InfrastructureMap from '@/components/infrastructure/infrastructure-map.vu
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { ComponentContainer } from 'golden-layout';
 
 export default defineComponent({
     name: 'InfrastructureComponent',
 
+    provide() {
+        return {
+            goldenLayoutKeyInjection: this.goldenLayoutKey,
+        };
+    },
+
     props: {
-        container: {
-            type: ComponentContainer,
-            required: false,
-            default: undefined,
-        },
-    },
-
-    created() {
-        this.configureContainer(); 
-    },
-
-    methods: {
-        configureContainer() {
-            if (!this.container) {
-                return;
-            }
-
-            this.container.on('resize', () => (this.$refs.infrastructureMap as { resize: () => void }).resize());
+        goldenLayoutKey: {
+            type: String,
+            required: true,
         },
     },
 });

--- a/web/client/src/components/infrastructure/infrastructure-legend.vue
+++ b/web/client/src/components/infrastructure/infrastructure-legend.vue
@@ -27,7 +27,7 @@
                         :src="iconUrl + elementType + iconExtension"
                         alt=""
                     >
-                    {{ elementTypeLabels[elementType] ?? elementType }}
+                    {{ getElementLabel(elementType) }}
                 </template>
             </v-checkbox>
         </template>
@@ -69,13 +69,16 @@ export default defineComponent({
             legendControlTypes,
             iconUrl,
             iconExtension,
-            elementTypeLabels: ElementTypeLabels as { [elementType: string]: string },
         };
     },
 
     methods: {
         hasImage(elementType: string) {
             return !SpecialLegendControls.includes(elementType);
+        },
+
+        getElementLabel(elementType: string) {
+            return ElementTypeLabels[elementType] ?? elementType;
         },
 
         emitChange(event: Event) {

--- a/web/client/src/components/infrastructure/infrastructure-legend.vue
+++ b/web/client/src/components/infrastructure/infrastructure-legend.vue
@@ -1,0 +1,113 @@
+<template>
+    <v-sheet
+        ref="mapLegend"
+        class="infrastructure-map-legend"
+        :elevation="5"
+    >
+        <template
+            v-for="(elementType, index) in legendControlTypes"
+            :key="index"
+        >
+            <v-checkbox
+                :ref="elementType"
+                :model-value="checkedControls"
+                :name="elementType"
+                :value="elementType"
+                class="legend-key"
+                color="primary"
+                density="compact"
+                min-height="0px"
+                hide-details
+                @input="emitChange"
+            >
+                <template #label>
+                    <img
+                        v-if="hasImage(elementType)"
+                        class="legend-key-icon"
+                        :src="iconUrl + elementType + iconExtension"
+                        alt=""
+                    >
+                    {{ elementTypeLabels[elementType] ?? elementType }}
+                </template>
+            </v-checkbox>
+        </template>
+    </v-sheet>
+</template>
+
+<script lang="ts">
+import { ElementTypeLabels, ElementTypes } from '@/components/infrastructure/elementTypes.js';
+import { iconExtension, iconUrl } from '@/components/infrastructure/addIcons';
+import { defineComponent } from 'vue';
+
+export const SpecialLegendControl = {
+    RISING: 'Rising',
+    FALLING: 'Falling',
+};
+export const SpecialLegendControls = Object.values(SpecialLegendControl);
+const legendControlTypes = [
+    ...ElementTypes,
+    ...SpecialLegendControls,
+];
+
+export default defineComponent({
+    name: 'InfrastructureLegend',
+
+    props: {
+        checkedControls: {
+            type: Array,
+            required: true,
+        },
+    },
+
+    emits: [
+        'checked',
+        'unchecked',
+    ],
+
+    data() {
+        return {
+            legendControlTypes,
+            iconUrl,
+            iconExtension,
+            elementTypeLabels: ElementTypeLabels as { [elementType: string]: string },
+        };
+    },
+
+    methods: {
+        hasImage(elementType: string) {
+            return !SpecialLegendControls.includes(elementType);
+        },
+
+        emitChange(event: Event) {
+            const eventTarget = event.target as HTMLInputElement;
+
+            this.$emit(
+                eventTarget.checked ? 'checked' : 'unchecked',
+                eventTarget.value,
+            );
+        },
+    },
+});
+</script>
+
+<style scoped>
+.infrastructure-map-legend {
+    padding: 10px 10px 20px;
+    height: fit-content;
+    margin-bottom: 40px;
+    width: fit-content;
+}
+
+.legend-key {
+    height: 1.5em;
+    margin-right: 5px;
+    margin-left: 5px;
+}
+
+.legend-key-icon {
+    margin-right: 7px;
+    margin-left: 7px;
+    display: inline-block;
+    height: 1em;
+}
+</style>

--- a/web/client/src/components/infrastructure/infrastructure-map.vue
+++ b/web/client/src/components/infrastructure/infrastructure-map.vue
@@ -53,6 +53,8 @@ const initiallyCheckedControls = [
     ...SpecialLegendControls,
 ];
 
+const localStorageCheckedLegendControlKey = 'infrastructure.checkedLegendControls';
+
 const mapDefaults = {
     attributionControl: false,
     zoom: 18,
@@ -147,6 +149,13 @@ export default defineComponent({
         },
     },
 
+    created() {
+        const checkedControlsString = window.localStorage.getItem(localStorageCheckedLegendControlKey);
+        if (checkedControlsString) {
+            this.checkedControls = JSON.parse(checkedControlsString);
+        }
+    },
+
     methods: {
         resize() {
             if (!this.libreGLMap) {
@@ -157,14 +166,16 @@ export default defineComponent({
         },
 
         onLegendControlChanged(legendControl: string, checked: boolean) {
-            if (!this.libreGLMap) {
-                return;
-            }
-
             if (checked) {
                 this.checkedControls.push(legendControl);
             } else {
                 this.checkedControls = this.checkedControls.filter((control) => control !== legendControl);
+            }
+
+            window.localStorage.setItem(localStorageCheckedLegendControlKey, JSON.stringify(this.checkedControls));
+
+            if (!this.libreGLMap) {
+                return;
             }
 
             if (SpecialLegendControls.includes(legendControl)) {

--- a/web/client/src/components/infrastructure/infrastructure-map.vue
+++ b/web/client/src/components/infrastructure/infrastructure-map.vue
@@ -4,38 +4,12 @@
             ref="map"
             class="map infrastructure-map"
         />
-        <v-sheet
-            ref="mapLegend"
-            class="map-overlay infrastructure-map-legend"
-            :elevation="5"
-        >
-            <template
-                v-for="(elementType, index) in legendControlTypes"
-                :key="index"
-            >
-                <v-checkbox
-                    :ref="elementType"
-                    v-model="checkedControls"
-                    :name="elementType"
-                    :value="elementType"
-                    class="legend-key"
-                    color="primary"
-                    density="compact"
-                    min-height="0px"
-                    hide-details
-                >
-                    <template #label>
-                        <img
-                            v-if="hasImage(elementType)"
-                            class="legend-key-icon"
-                            :src="iconUrl + elementType + iconExtension"
-                            alt=""
-                        >
-                        {{ elementTypeLabels[elementType] ?? elementType }}
-                    </template>
-                </v-checkbox>
-            </template>
-        </v-sheet>
+        <infrastructure-legend
+            class="map-overlay"
+            :checked-controls="checkedControls"
+            @checked="(name) => onLegendControlChanged(name, true)"
+            @unchecked="(name) => onLegendControlChanged(name, false)"
+        />
         <div
             ref="infrastructureTooltip"
             class="infrastructureTooltip infrastructure-tooltip"
@@ -48,6 +22,10 @@
     </div>
 </template>
 
+<script setup lang="ts">
+import InfrastructureLegend from '@/components/infrastructure/infrastructure-legend.vue';
+</script>
+
 <script lang="ts">
 import { mapState } from 'vuex';
 import { InfrastructureNamespace } from '@/stores/infrastructure-store';
@@ -59,23 +37,20 @@ import {
 } from './infrastructureMap';
 import { FilterSpecification, Map } from 'maplibre-gl';
 import { createInfrastructureMapStyle } from './mapStyle';
-import { addIcons, iconExtension, iconUrl } from './addIcons';
-import { ElementTypes, ElementType, ElementTypeLabels } from './elementTypes';
+import { addIcons } from './addIcons';
+import { ElementTypes, ElementType } from './elementTypes';
 import { defineComponent } from 'vue';
 import { transformUrl } from '@/api/api-client';
 import { ThemeInstance, useTheme } from 'vuetify';
+import { SpecialLegendControls, SpecialLegendControl } from '@/components/infrastructure/infrastructure-legend.vue';
 
-const specialLayoutControls = ['Rising', 'Falling'];
 const initiallyCheckedControls = [
     ElementType.STATION,
+    ElementType.HALT,
     ElementType.MAIN_SIGNAL,
     ElementType.APPROACH_SIGNAL,
     ElementType.END_OF_TRAIN_DETECTOR,
-    ...specialLayoutControls,
-];
-const legendControlTypes = [
-    ...ElementTypes,
-    ...specialLayoutControls,
+    ...SpecialLegendControls,
 ];
 
 const mapDefaults = {
@@ -102,11 +77,7 @@ export default defineComponent({
     data() {
         return {
             libreGLMap: null as (Map | null),
-            legendControlTypes,
             checkedControls: Array.from(initiallyCheckedControls),
-            iconUrl,
-            iconExtension,
-            elementTypeLabels: ElementTypeLabels as { [elementType: string]: string },
         };
     },
 
@@ -124,35 +95,6 @@ export default defineComponent({
             // Re-instantiating the map on infrastructure change currently leads to duplicated icon fetching on change.
             // @ts-ignore type instantiation for some reason is too deep
             this.libreGLMap = newInfrastructure ? this.createMap(newInfrastructure) : null;
-        },
-
-        checkedControls(newCheckedControls: string[], oldCheckedControls: string[]) {
-            if (!this.libreGLMap) {
-                return;
-            }
-
-            const controlsToDeactivate = oldCheckedControls.filter((control) => !newCheckedControls.includes(control));
-            const controlsToActivate = newCheckedControls.filter((control) => !oldCheckedControls.includes(control));
-
-            controlsToDeactivate.forEach((control) => {
-                if (specialLayoutControls.includes(control)) {
-                    this.evaluateSpecialLegendControls();
-
-                    return;
-                }
-
-                this.setElementTypeVisibility(control, false);
-            });
-
-            controlsToActivate.forEach((control) => {
-                if (specialLayoutControls.includes(control)) {
-                    this.evaluateSpecialLegendControls();
-
-                    return;
-                }
-
-                this.setElementTypeVisibility(control, true);
-            });
         },
 
         currentSearchedMapPosition(mapPosition: MapPosition) {
@@ -214,8 +156,24 @@ export default defineComponent({
             this.libreGLMap.resize();
         },
 
-        hasImage(elementType: string) {
-            return !specialLayoutControls.includes(elementType);
+        onLegendControlChanged(legendControl: string, checked: boolean) {
+            if (!this.libreGLMap) {
+                return;
+            }
+
+            if (checked) {
+                this.checkedControls.push(legendControl);
+            } else {
+                this.checkedControls = this.checkedControls.filter((control) => control !== legendControl);
+            }
+
+            if (SpecialLegendControls.includes(legendControl)) {
+                this.evaluateSpecialLegendControls();
+
+                return;
+            }
+
+            this.setElementTypeVisibility(legendControl, checked);
         },
 
         setElementTypeVisibility(elementType: string, visible: boolean) {
@@ -239,8 +197,8 @@ export default defineComponent({
                 return;
             }
 
-            const rising_checked = (this.$refs.Rising as HTMLInputElement).checked;
-            const falling_checked = (this.$refs.Falling as HTMLInputElement).checked;
+            const rising_checked = this.checkedControls.includes(SpecialLegendControl.RISING);
+            const falling_checked = this.checkedControls.includes(SpecialLegendControl.FALLING);
 
             let filter: FilterSpecification;
             if (!rising_checked && falling_checked) {
@@ -320,26 +278,6 @@ export default defineComponent({
     bottom: 0;
     right: 0;
     margin-right: 20px;
-}
-
-.infrastructure-map-legend {
-    padding: 10px 10px 20px;
-    height: fit-content;
-    margin-bottom: 40px;
-    width: fit-content;
-}
-
-.legend-key {
-    height: 1.5em;
-    margin-right: 5px;
-    margin-left: 5px;
-}
-
-.legend-key-icon {
-    margin-right: 7px;
-    margin-left: 7px;
-    display: inline-block;
-    height: 1em;
 }
 </style>
 

--- a/web/client/src/components/infrastructure/infrastructure-map.vue
+++ b/web/client/src/components/infrastructure/infrastructure-map.vue
@@ -53,8 +53,6 @@ const initiallyCheckedControls = [
     ...SpecialLegendControls,
 ];
 
-const localStorageCheckedLegendControlKey = 'infrastructure.checkedLegendControls';
-
 const mapDefaults = {
     attributionControl: false,
     zoom: 18,
@@ -71,6 +69,11 @@ export type MapPosition = {
 
 export default defineComponent({
     name: 'InfrastructureMap',
+    inject: {
+        goldenLayoutKeyInjection: {
+            default: '',
+        },
+    },
 
     setup() {
         return { currentTheme: useTheme().global };
@@ -84,6 +87,10 @@ export default defineComponent({
     },
 
     computed: {
+        checkedLegendControlLocalStorageKey() {
+            return `infrastructure[${this.goldenLayoutKeyInjection}].checkedControls`;
+        },
+
         ...mapState(InfrastructureNamespace, [
             'currentInfrastructure',
             'currentSearchedMapPosition',
@@ -150,7 +157,7 @@ export default defineComponent({
     },
 
     created() {
-        const checkedControlsString = window.localStorage.getItem(localStorageCheckedLegendControlKey);
+        const checkedControlsString = window.localStorage.getItem(this.checkedLegendControlLocalStorageKey);
         if (checkedControlsString) {
             this.checkedControls = JSON.parse(checkedControlsString);
         }
@@ -172,7 +179,7 @@ export default defineComponent({
                 this.checkedControls = this.checkedControls.filter((control) => control !== legendControl);
             }
 
-            window.localStorage.setItem(localStorageCheckedLegendControlKey, JSON.stringify(this.checkedControls));
+            window.localStorage.setItem(this.checkedLegendControlLocalStorageKey, JSON.stringify(this.checkedControls));
 
             if (!this.libreGLMap) {
                 return;

--- a/web/client/src/golden-layout/golden-layout-adapter.vue
+++ b/web/client/src/golden-layout/golden-layout-adapter.vue
@@ -13,6 +13,7 @@
             >
                 <component
                     :is="pair[1].glc"
+                    :golden-layout-key="GlcKeyPrefix + pair[0]"
                     :container="pair[1].container"
                 />
             </golden-layout-component>


### PR DESCRIPTION
This PR allows saving the currently checked legend controls in local storage.

This PR also refactors and simplifies the handling of the checked legend controls and fixes a problem regarding the handling of special legend controls (Rising and Falling).

This PR also enables "Halt" by default.

* Closes #81