### PR TITLE
Fix broken paths and temporary folders in preprocessing script

### DIFF
--- a/generate-osm/main.go
+++ b/generate-osm/main.go
@@ -92,6 +92,11 @@ func generateOsm(generateLines bool, inputFile string) error {
 		if err = os.Mkdir(tempLinesDir, 0755); err != nil {
 			return errors.New("Failed to create lines folder: " + err.Error())
 		}
+		if _, err := os.Stat(tempDBResoucesDir); os.IsNotExist(err) {
+		    if err = os.Mkdir(tempDBResoucesDir, 0755); err != nil {
+                return errors.New("Failed to create DBResources folder: " + err.Error())
+            }
+		}
 
 		for _, refId := range refs {
 			lineOsmFile, err := filepath.Abs(tempLinesDir + "/" + refId + ".xml")

--- a/generate-osm/osm-utils/generate-stations.go
+++ b/generate-osm/osm-utils/generate-stations.go
@@ -7,8 +7,8 @@ import (
 )
 
 func GenerateStationsAndHalts(inputFilePath string, tempFolderPath string) (searchFile SearchFile, stationHaltOsm Osm) {
-	stationsUnfilteredFilePath, _ := filepath.Abs(tempFolderPath + "./stationsUnfiltered.osm.pbf")
-	stationsFile, _ := filepath.Abs(tempFolderPath + "./stations.xml")
+	stationsUnfilteredFilePath, _ := filepath.Abs(tempFolderPath + "/stationsUnfiltered.osm.pbf")
+	stationsFile, _ := filepath.Abs(tempFolderPath + "/stations.xml")
 
 	ExecuteOsmFilterCommand([]string{
 		inputFilePath,


### PR DESCRIPTION
This PR fixes broken paths under ubuntu and dependence on temporary folders.

* Fixes #74