### PR TITLE
Remove go executable from tracking in UNIX systems

### DIFF
--- a/generate-osm/.gitignore
+++ b/generate-osm/.gitignore
@@ -2,4 +2,8 @@
 temp/*
 
 *.exe
+# We cannot ignore all executables generically on UNIX systems as they do not have a fixed extension (unlike on windows)
+# Thus we have to ignore the generated executable explicitly:
+transform-osm
+
 *.xml


### PR DESCRIPTION
See the above, the change from #75 was wrongfully reverted in #89

* Related to #75 